### PR TITLE
All gem dependencies are updated to the latest versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 rvm:
- - 1.8.7
  - 1.9.2
  - 1.9.3
  - 2.0.0
  - 2.1.0
- - ree
  - rbx
  - jruby
 notifications:

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@
 require 'bundler'
 Bundler::GemHelper.install_tasks
 
-testing_rubies = %w[1.8.7 1.9.2 ree ree-1.8.7-2010.01 jruby rbx]
+testing_rubies = %w[1.9.2 1.9.3 2.0.0 2.1.0 jruby rbx]
 
 task :default => :test
 
@@ -41,7 +41,7 @@ namespace :install do
 
       puts '- Installing bundler...'
       system "rvm #{ruby} gem install --no-rdoc --no-ri bundler"
-      
+
       puts '- Installing bundle...'
       system "rvm #{ruby} exec bundle install"
     end

--- a/lib/sheets/parsers/nokogiri_ods_parser.rb
+++ b/lib/sheets/parsers/nokogiri_ods_parser.rb
@@ -1,11 +1,11 @@
 require 'nokogiri'
-require 'zip/zip'
+require 'zip'
 
 class Sheets::Parsers::NokogiriOdsParser < Sheets::Parsers::Base
   parses :ods
 
   def to_array
-    rows.collect do |row| 
+    rows.collect do |row|
       table_cells = []
       row.xpath('table:table-cell').each do |cell|
         repeat = cell.attributes["number-columns-repeated"].text.to_i if cell.attributes["number-columns-repeated"]
@@ -21,7 +21,7 @@ class Sheets::Parsers::NokogiriOdsParser < Sheets::Parsers::Base
 
   # returns the zipfile object for the document
   def zipfile
-    @zipfile ||= Zip::ZipFile.open( @file_path )
+    @zipfile ||= Zip::File.open( @file_path )
   end
 
   def content_doc

--- a/lib/sheets/parsers/nokogiri_xlsx_parser.rb
+++ b/lib/sheets/parsers/nokogiri_xlsx_parser.rb
@@ -1,5 +1,5 @@
 require 'nokogiri'
-require 'zip/zip'
+require 'zip'
 
 class Sheets::Parsers::NokogiriXlsxParser < Sheets::Parsers::Base
   parses :xlsx
@@ -44,7 +44,7 @@ class Sheets::Parsers::NokogiriXlsxParser < Sheets::Parsers::Base
 
   # returns the zipfile object for the document
   def zipfile
-    @zipfile ||= Zip::ZipFile.open( @file_path )
+    @zipfile ||= Zip::File.open( @file_path )
   end
 
   # returns a nokogiri document for the workbook

--- a/sheets.gemspec
+++ b/sheets.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "sheets"
 
-  s.add_dependency('spreadsheet', '~>0.6.5.2')
-  s.add_dependency('rubyzip', '~>0.9.4')
-  s.add_dependency('nokogiri', '~>1.4.3.1')
+  s.add_dependency('spreadsheet', '~>0.9.7')
+  s.add_dependency('rubyzip', '~>1.1.0')
+  s.add_dependency('nokogiri', '~>1.6.1')
 
-  s.add_development_dependency('rake', '0.9.2')
+  s.add_development_dependency('rake', '~>10.1.1')
   s.add_development_dependency('simplecov')
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
Nokogiri >= 1.6.0 drops support for 1.8.7. ree is subsequently dropped, as well.
